### PR TITLE
Support resuming incomplete downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ $ gfile download https://66.gigafile.nu/0320-b36ec21d4a56b143537e12df7388a5367
 
 $ gfile -h
 usage: Gfile [-h] [--version] [-p] [-o OUTPUT] [--aria2 [ARIA2]] [-n THREAD_NUM] [-s CHUNK_SIZE] [-m CHUNK_COPY_SIZE] [-t TIMEOUT] [-k KEY]
-             [--mute] [--verify | --no-verify]
+             [--mute] [--verify | --no-verify] [--resume]
              {download,upload} file_or_url
 
 positional arguments:
@@ -55,6 +55,7 @@ options:
   --mute                mute initial message and warnings (only the final result and errors will be shown)
   --verify              enable verification (default)
   --no-verify           disable verification
+  --resume              resume incomplete downloads (default)
 ```
 
 ### Module

--- a/gfile/cmd.py
+++ b/gfile/cmd.py
@@ -32,6 +32,7 @@ def main():
     verify_group = parser.add_mutually_exclusive_group()
     verify_group.add_argument('--verify', dest='verify', action='store_true', default=True, help='enable verification (default)')
     verify_group.add_argument('--no-verify', dest='verify', action='store_false', help='disable verification')
+    parser.add_argument('--resume', dest='resume', action='store_true', default=True, help='resume incomplete downloads (default)')
 
     args = parser.parse_args()
 

--- a/gfile/gfile.py
+++ b/gfile/gfile.py
@@ -80,7 +80,7 @@ def split_file(input_file, out, target_size=None, start=0, chunk_copy_size=1024*
 
 class GFile:
     def __init__(self, file_or_url, progress=False, thread_num=4, chunk_size=1024*1024*10, chunk_copy_size=1024*1024, timeout=10,
-                 aria2=False, key=None, mute=False, verify=True, **kwargs) -> None:
+                 aria2=False, key=None, mute=False, verify=True, resume=True, **kwargs) -> None:
         self.file_or_url = file_or_url
         self.chunk_size = size_str_to_bytes(chunk_size)
         self.chunk_copy_size = size_str_to_bytes(chunk_copy_size)
@@ -97,6 +97,7 @@ class GFile:
         self.mute = mute
         self.verify = verify
         self.key = key
+        self.resume = resume
 
 
     def upload_chunk(self, chunk_no, chunks):
@@ -294,13 +295,29 @@ class GFile:
                 continue
 
             temp = filename + '.dl'
-            with self.session.get(download_url, stream=True) as r:
+            resume_pos = 0
+            if self.resume and Path(temp).exists():
+                resume_pos = Path(temp).stat().st_size
+
+            headers = {}
+            if resume_pos > 0:
+                headers['Range'] = f'bytes={resume_pos}-'
+
+            with self.session.get(download_url, stream=True, headers=headers) as r:
                 r.raise_for_status()
-                filesize = int(r.headers['Content-Length'])
+                if resume_pos > 0 and r.status_code == 206:
+                    filesize = resume_pos + int(r.headers['Content-Length'])
+                    if not self.mute:
+                        print(f'Resuming download from {bytes_to_size_str(resume_pos)} / {bytes_to_size_str(filesize)}')
+                else:
+                    filesize = int(r.headers['Content-Length'])
+                    resume_pos = 0  # server doesn't support range, start over
+
                 if self.progress:
                     desc = filename if len(filename) <= 20 else filename[0:11] + '..' + filename[-7:]
-                    self.pbar = tqdm(total=filesize, unit='B', unit_scale=True, unit_divisor=1024, desc=desc)
-                with open(temp, 'wb') as f:
+                    self.pbar = tqdm(total=filesize, initial=resume_pos, unit='B', unit_scale=True, unit_divisor=1024, desc=desc)
+                mode = 'ab' if resume_pos > 0 else 'wb'
+                with open(temp, mode) as f:
                     for chunk in r.iter_content(chunk_size=self.chunk_copy_size):
                         f.write(chunk)
                         if self.pbar: self.pbar.update(len(chunk))


### PR DESCRIPTION
Thanks to @fireattack for building and maintaining this excellent tool. 
The clean codebase and well-structured design made it straightforward to
add this feature. Great work on gfile! 

Summary                                                                 
                                                            
  - Add ability to resume interrupted downloads using HTTP Range header   
  - Detect existing .dl temp files and continue from where the previous
  download left off                                                       
  - Automatically fall back to a fresh download if the server does not
  support range requests (no 206 response)                                
  - Progress bar correctly starts from the resume position
  - Add --resume CLI flag (enabled by default)                            
                                                            
  Changes                                        

  - gfile/gfile.py: Add resume parameter to GFile. In download(), check   
  for existing .dl file, send Range header, and write in append mode
  - gfile/cmd.py: Add --resume CLI flag                                   
  - README.md: Add --resume to help output                  
                                                 
  Tested

  - Fresh download works normally
  - After interruption, re-running shows Resuming download from ... and
  resumes correctly                                                       
  - MD5 of the initial portion matches before and after resume (no
  overwrite)                                                              
  - Data at the resume boundary matches a direct range request to the
  server (no duplication or gap)                                          
  - Without a .dl file, download starts from the beginning as expected